### PR TITLE
fix: set home directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,4 +42,6 @@ RUN chmod -R g=u /root
 
 WORKDIR /root
 
+ENV HOME /root
+
 ENTRYPOINT [ "/bin/zsh" ]


### PR DESCRIPTION
This Merge Request aims to fix mycli not working, because the default `$HOME` is being set to `/`